### PR TITLE
Allow esbuild 0.19 (and later) as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "typescript": "^5.0.4"
   },
   "peerDependencies": {
-    "esbuild": ">=0.17.0 <0.19.0"
+    "esbuild": ">=0.17.0"
   }
 }


### PR DESCRIPTION
This project is currently preventing my setup from updating esbuild to version 0.19, due to the strict peerdependency version constraints. I would propose to lossen them and not supply an upper range. Due to the way the versioning works, it would never update to a new major (e.g. 1.x) version anyway.